### PR TITLE
Fixed saving issue with variation product membership and participants

### DIFF
--- a/includes/classes/class-woo-civi-membership.php
+++ b/includes/classes/class-woo-civi-membership.php
@@ -683,11 +683,11 @@ class WPCV_Woo_Civi_Membership {
 	 *
 	 * @since 3.0
 	 *
-	 * @param integer              $loop The position in the loop.
 	 * @param WC_Product_Variation $variation The Product Variation object.
+	 * @param integer              $loop The position in the loop.
 	 * @param string               $entity The CiviCRM Entity Type.
 	 */
-	public function variation_saved( $loop, $variation, $entity ) {
+	public function variation_saved( $variation, $loop, $entity ) {
 
 		// Bail if this is not a CiviCRM Membership.
 		if ( $entity !== 'civicrm_membership' ) {

--- a/includes/classes/class-woo-civi-participant.php
+++ b/includes/classes/class-woo-civi-participant.php
@@ -112,6 +112,9 @@ class WPCV_Woo_Civi_Participant {
 		// Add Event and Participant Role to the Product Variation "CiviCRM Settings".
 		add_action( 'wpcv_woo_civi/product/variation/block/middle', [ $this, 'attributes_add_markup' ], 20, 4 );
 
+		// Save Event and Participant Role for the Product Variation.
+		add_action( 'wpcv_woo_civi/product/variation/attributes/saved/after', [ $this, 'variation_saved' ], 10, 3 );
+
 		// Add Participant data to the Product "Bulk Edit" and "Quick Edit" markup.
 		//add_action( 'wpcv_woo_civi/product/bulk_edit/after', [ $this, 'bulk_edit_add_markup' ] );
 		//add_action( 'wpcv_woo_civi/product/quick_edit/after', [ $this, 'quick_edit_add_markup' ] );
@@ -1050,11 +1053,11 @@ class WPCV_Woo_Civi_Participant {
 	 *
 	 * @since 3.0
 	 *
-	 * @param integer              $loop The position in the loop.
 	 * @param WC_Product_Variation $variation The Product Variation object.
+	 * @param integer              $loop The position in the loop.
 	 * @param string               $entity The CiviCRM Entity Type.
 	 */
-	public function variation_saved( $loop, $variation, $entity ) {
+	public function variation_saved( $variation, $loop, $entity ) {
 
 		// Bail if this is not a CiviCRM Participant.
 		if ( $entity !== 'civicrm_participant' ) {


### PR DESCRIPTION
When creating a product with variations and setting the CiviCRM Entity to 'Membership' or 'Participant', setting the Membership Type or Participant Role within the variation tab of the product did not save after clicking the 'Save changes' button. This PR fixes the parameter order of the variation_save functions used to save the membership type and participant role. The action to save participants did not exist and was also added.